### PR TITLE
Don't deadlock if askPermissionForUrl: is called from the main queue.

### DIFF
--- a/AppSandboxFileAccess/AppSandboxFileAccess.m
+++ b/AppSandboxFileAccess/AppSandboxFileAccess.m
@@ -81,7 +81,7 @@
 	url = [NSURL fileURLWithPath:path];
 	
 	// display the open panel
-	dispatch_sync(dispatch_get_main_queue(), ^{
+	void (^display_panel_block)() = ^{
 		NSOpenPanel *openPanel = [NSOpenPanel openPanel];
 		[openPanel setMessage:self.message];
 		[openPanel setCanCreateDirectories:NO];
@@ -99,8 +99,14 @@
 		if (openPanelButtonPressed == NSFileHandlingPanelOKButton) {
 			allowedUrl = [openPanel URL];
 		}
-	});
-	
+	};
+	dispatch_queue_t main_queue = dispatch_get_main_queue();
+	if (dispatch_get_current_queue() == main_queue) {
+		display_panel_block();
+	} else {
+		dispatch_sync(main_queue, display_panel_block);
+	}
+
 	return allowedUrl;
 }
 


### PR DESCRIPTION
dispatch_sync() is documented to deadlock if the target queue is the
same as the current one.  This happens when AppSandboxFileAccess is used
from the main thread.  Fix the deadlock by explicitly checking for the
current queue and calling the block directly.
