### PR TITLE
Try harder to get application's name.

### DIFF
--- a/AppSandboxFileAccess/AppSandboxFileAccess.m
+++ b/AppSandboxFileAccess/AppSandboxFileAccess.m
@@ -42,6 +42,7 @@
 #endif
 
 #define CFBundleDisplayName @"CFBundleDisplayName"
+#define CFBundleName        @"CFBundleName"
 
 @implementation AppSandboxFileAccess
 
@@ -53,6 +54,11 @@
 	self = [super init];
 	if (self) {
 		NSString *applicationName = [[[NSBundle mainBundle] localizedInfoDictionary] objectForKey:CFBundleDisplayName];
+		if (!applicationName)
+			applicationName = [[NSBundle mainBundle] objectForInfoDictionaryKey:CFBundleDisplayName];
+		if (!applicationName)
+			applicationName = [[NSBundle mainBundle] objectForInfoDictionaryKey:CFBundleName];
+
 		self.title = @"Allow Access";
 		self.message = [NSString stringWithFormat:@"%@ needs to access this path to continue. Click Allow to continue.", applicationName];
 		self.prompt = @"Allow";


### PR DESCRIPTION
CFBundleDisplayName may lack localization or may be missing altogether
(default Info.plist files created by Xcode don't have it).  Try to use
non-localized entry or CFBundleName as fallbacks.  This is similar to
what e.g.  Sparkle does.
