### PR TITLE
Add support for custom URL bookmark persistence.

### DIFF
--- a/AppSandboxFileAccess.xcodeproj/project.pbxproj
+++ b/AppSandboxFileAccess.xcodeproj/project.pbxproj
@@ -487,6 +487,7 @@
 		201DCD561840BDE600B43456 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -502,6 +503,7 @@
 		201DCD571840BDE600B43456 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -637,6 +639,7 @@
 				C212FF001A7E944E00BE3532 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/AppSandboxFileAccess/Classes/AppSandboxFileAccess.h
+++ b/AppSandboxFileAccess/Classes/AppSandboxFileAccess.h
@@ -41,6 +41,7 @@
 
 @protocol AppSandboxFileAccessProtocol<NSObject>
 
+@required
 - (NSData *)bookmarkDataForURL:(NSURL *)url;
 - (void)setBookmarkData:(NSData *)data forURL:(NSURL *)url;
 - (void)clearBookmarkDataForURL:(NSURL *)url;

--- a/AppSandboxFileAccess/Classes/AppSandboxFileAccess.h
+++ b/AppSandboxFileAccess/Classes/AppSandboxFileAccess.h
@@ -36,6 +36,20 @@
 #import <Foundation/Foundation.h>
 @import AppKit;
 
+#pragma mark -
+#pragma mark AppSandboxFileAccessProtocol
+
+@protocol AppSandboxFileAccessProtocol<NSObject>
+
+- (NSData *)bookmarkDataForURL:(NSURL *)url;
+- (void)setBookmarkData:(NSData *)data forURL:(NSURL *)url;
+- (void)clearBookmarkDataForURL:(NSURL *)url;
+
+@end
+
+#pragma mark -
+#pragma mark AppSandboxFileAccess
+
 typedef void (^AppSandboxFileAccessBlock)();
 typedef void (^AppSandboxFileSecurityScopeBlock)(NSURL *securityScopedFileURL, NSData *bookmarkData);
 
@@ -53,6 +67,11 @@ typedef void (^AppSandboxFileSecurityScopeBlock)(NSURL *securityScopedFileURL, N
  Default: "Allow"
  */
 @property (readwrite, copy, nonatomic) NSString *prompt;
+
+/*! @brief This is an optional delegate object that can be provided to customize the persistance of bookmark data (e.g. in a Core Data database).
+ Default: nil (Default uses the AppSandboxFileAccessPersist class.)
+ */
+@property (nonatomic, weak) id <AppSandboxFileAccessProtocol> bookmarkPersistanceDelegate;
 
 /*! @brief Create the object with the default values. */
 + (AppSandboxFileAccess *)fileAccess;

--- a/AppSandboxFileAccess/Classes/AppSandboxFileAccessPersist.h
+++ b/AppSandboxFileAccess/Classes/AppSandboxFileAccessPersist.h
@@ -34,11 +34,12 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "AppSandboxFileAccess.h"
 
-@interface AppSandboxFileAccessPersist : NSObject
+@interface AppSandboxFileAccessPersist : NSObject <AppSandboxFileAccessProtocol>
 
-+ (NSData *)bookmarkDataForURL:(NSURL *)url;
-+ (void)setBookmarkData:(NSData *)data forURL:(NSURL *)url;
-+ (void)clearBookmarkDataForURL:(NSURL *)url;
+- (NSData *)bookmarkDataForURL:(NSURL *)url;
+- (void)setBookmarkData:(NSData *)data forURL:(NSURL *)url;
+- (void)clearBookmarkDataForURL:(NSURL *)url;
 
 @end

--- a/AppSandboxFileAccess/Classes/AppSandboxFileAccessPersist.m
+++ b/AppSandboxFileAccess/Classes/AppSandboxFileAccessPersist.m
@@ -46,7 +46,7 @@
 	return [NSString stringWithFormat:@"bd_%1$@", urlStr];
 }
 
-+ (NSData *)bookmarkDataForURL:(NSURL *)url {
+- (NSData *)bookmarkDataForURL:(NSURL *)url {
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	
 	// loop through the bookmarks one path at a time down the URL
@@ -64,13 +64,13 @@
 	return nil;
 }
 
-+ (void)setBookmarkData:(NSData *)data forURL:(NSURL *)url {
+- (void)setBookmarkData:(NSData *)data forURL:(NSURL *)url {
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	NSString *key = [AppSandboxFileAccessPersist keyForBookmarkDataForURL:url];
 	[defaults setObject:data forKey:key];
 }
 
-+ (void)clearBookmarkDataForURL:(NSURL *)url {
+- (void)clearBookmarkDataForURL:(NSURL *)url {
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	NSString *key = [AppSandboxFileAccessPersist keyForBookmarkDataForURL:url];
 	[defaults removeObjectForKey:key];


### PR DESCRIPTION
Adding support for a delegate class to persist URL bookmark data in a custom manner (e.g. into a Core Data database) instead of the default user defaults. A protocol (`AppSandboxFileAccessProtocol`) is defined that the delegate must conform to.