### PR TITLE
Update AppSandboxFileAccess.h

### DIFF
--- a/AppSandboxFileAccess/Classes/AppSandboxFileAccess.h
+++ b/AppSandboxFileAccess/Classes/AppSandboxFileAccess.h
@@ -51,7 +51,7 @@
 #pragma mark -
 #pragma mark AppSandboxFileAccess
 
-typedef void (^AppSandboxFileAccessBlock)();
+typedef void (^AppSandboxFileAccessBlock)(void);
 typedef void (^AppSandboxFileSecurityScopeBlock)(NSURL *securityScopedFileURL, NSData *bookmarkData);
 
 @interface AppSandboxFileAccess : NSObject


### PR DESCRIPTION
Adding 'void' in block prototype to remove compiler warning "This block declaration is not a prototype", see: <https://stackoverflow.com/questions/47916585/objective-c-block-parameter-issue-this-block-declaration-is-not-a-prototype>